### PR TITLE
adding tokens

### DIFF
--- a/Compiler/src/hulkTokens.rs
+++ b/Compiler/src/hulkTokens.rs
@@ -1,0 +1,54 @@
+#[derive(Debug, PartialEq)]
+pub enum KeywordToken {
+    PRINT,
+    WHILE,
+    ELIF,
+    ELSE,
+    IF,
+    IN,
+    LET,
+    TRUE,
+    FALSE,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum OperatorToken {
+    MUL,
+    DIV,
+    PLUS,
+    MINUS,
+    MOD,
+    POW,
+    NEG,
+    NOT,
+    EQ,
+    NEQ,
+    GT,
+    GTE,
+    LT,
+    LTE,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum DelimiterToken {
+    SEMICOLON,
+    COMMA,
+    LPAREN,
+    RPAREN,
+    LBRACE,
+    RBRACE,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum IdentifierToken {
+    IDENTIFIER(String),
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Token {
+    Keyword(KeywordToken),
+    Operator(OperatorToken),
+    Delimiter(DelimiterToken),
+    Identifier(IdentifierToken),
+    EOF,
+}

--- a/Compiler/src/main.rs
+++ b/Compiler/src/main.rs
@@ -18,7 +18,10 @@ fn main() {
         }
 
         match parser.parse(&input) {
-            Ok(expr) => println!("= {}", expr.eval()),
+            Ok(expr) => {   
+                println!("= {}", expr.eval());
+                println!("AST: {:?}", expr);
+            }
             Err(err) => eprintln!("Error de sintaxis: {:?}", err),
         }
     }


### PR DESCRIPTION
This pull request introduces significant updates to the token definitions and debugging output in the compiler. The most important changes include the addition of new token enums to represent different categories of tokens in the lexer and an enhancement to the `main` function to print the Abstract Syntax Tree (AST) for debugging purposes.

### Token system enhancements:
* [`Compiler/src/hulkTokens.rs`](diffhunk://#diff-56eb00631accbb6af19eac2456546c24e46a46bf73e60ba432e918c45db174caR1-R54): Added new enums (`KeywordToken`, `OperatorToken`, `DelimiterToken`, `IdentifierToken`, and `Token`) to categorize and represent tokens in the lexer, improving the structure and readability of the tokenization process.

### Debugging improvements:
* [`Compiler/src/main.rs`](diffhunk://#diff-9d499f7282c7a29d44363a315dc41f4e6f88b09809fe19b8ab53232e3787b0c7L21-R24): Enhanced the `main` function to print the AST (`expr`) after evaluating the expression, aiding in debugging and development.