### PR TITLE
adding tokens and better grammar

### DIFF
--- a/Compiler/src/ast.rs
+++ b/Compiler/src/ast.rs
@@ -1,20 +1,88 @@
+use crate::hulk_tokens::*;
+
 #[derive(Debug)]
 pub enum Expr {
-    Number(i64),
-    Add(Box<Expr>, Box<Expr>),
-    Sub(Box<Expr>, Box<Expr>),
-    Mul(Box<Expr>, Box<Expr>),
-    Div(Box<Expr>, Box<Expr>),
+    Number(i32),
+    Boolean(bool),
+    Str(String),
+    Identifier(String),
+    BinaryOp(Box<Expr>, OperatorToken, Box<Expr>),
+    UnaryOp(OperatorToken, Box<Expr>),
+    Print(Box<Expr>),
 }
 
 impl Expr {
-    pub fn eval(&self) -> i64 {
+    pub fn eval(&self) -> Result<i64, String> {
         match self {
-            Expr::Number(n) => *n,
-            Expr::Add(l, r) => l.eval() + r.eval(),
-            Expr::Sub(l, r) => l.eval() - r.eval(),
-            Expr::Mul(l, r) => l.eval() * r.eval(),
-            Expr::Div(l, r) => l.eval() / r.eval(),
+            Expr::Number(n) => Ok((*n).into()),
+            Expr::BinaryOp(left, op, right) => {
+                let left_val = left.eval()?;
+                let right_val = right.eval()?;
+                match op {
+                    OperatorToken::Plus => Ok(left_val + right_val),
+                    OperatorToken::Minus => Ok(left_val - right_val),
+                    OperatorToken::Mul => Ok(left_val * right_val),
+                    OperatorToken::Div => {
+                        if right_val == 0 {
+                            Err("Error: División por cero".to_string())
+                        } else {
+                            Ok(left_val / right_val)
+                        }
+                    }
+                    OperatorToken::Mod => Ok(left_val % right_val),
+                    OperatorToken::Pow => Ok(left_val.pow(right_val as u32)),
+                    OperatorToken::Eq => Ok((left_val == right_val) as i64),
+                    OperatorToken::Neq => Ok((left_val != right_val) as i64),
+                    OperatorToken::Gt => Ok((left_val > right_val) as i64),
+                    OperatorToken::Gte => Ok((left_val >= right_val) as i64),
+                    OperatorToken::Lt => Ok((left_val < right_val) as i64),
+                    OperatorToken::Lte => Ok((left_val <= right_val) as i64),
+                    _ => Err("Operador no soportado".to_string()),
+                }
+            }
+            Expr::UnaryOp(op, expr) => {
+                let val = expr.eval()?;
+                match op {
+                    OperatorToken::Neg => Ok(-val),
+                    OperatorToken::Not => Ok((val == 0) as i64),
+                    _ => Err("Operador unario no soportado".to_string()),
+                }
+            }
+            _ => Err("Expresión no soportada".to_string()),
+        }
+    }
+
+    pub fn to_tree(&self, indent: usize) -> String {
+        let padding = "  ".repeat(indent); // Sangría para cada nivel
+        match self {
+            Expr::Number(n) => format!("{}Number({})", padding, n),
+            Expr::Boolean(b) => format!("{}Boolean({})", padding, b),
+            Expr::Str(s) => format!("{}Str(\"{}\")", padding, s),
+            Expr::Identifier(id) => format!("{}Identifier({})", padding, id),
+            Expr::BinaryOp(left, op, right) => {
+                let op_str = format!("{:?}", op);
+                format!(
+                    "{}BinaryOp({})\n{}\n{}",
+                    padding,
+                    op_str,
+                    left.to_tree(indent + 1),
+                    right.to_tree(indent + 1)
+                )
+            }
+            Expr::UnaryOp(op, expr) => {
+                let op_str = format!("{:?}", op);
+                format!(
+                    "{}UnaryOp({})\n{}",
+                    padding,
+                    op_str,
+                    expr.to_tree(indent + 1)
+                )
+            }
+            Expr::Print(expr) => format!(
+                "{}Print\n{}",
+                padding,
+                expr.to_tree(indent + 1)
+            ),
         }
     }
 }

--- a/Compiler/src/hulk_idenfitifer.rs
+++ b/Compiler/src/hulk_idenfitifer.rs
@@ -1,0 +1,20 @@
+use super::*;
+
+pub struct Identifier {
+    pub position: TokenPosition,
+    pub id: String,
+}
+
+impl Identifier {
+    pub fn new(start: usize, end: usize, id: &str) -> Self {
+        Identifier {
+            position: TokenPosition::new(start, end),
+            id: id.to_string(),
+        }
+    }
+}
+impl Identifier {
+    pub fn get_position(&self) -> TokenPosition {
+        self.position
+    }
+}

--- a/Compiler/src/hulk_literal.rs
+++ b/Compiler/src/hulk_literal.rs
@@ -1,0 +1,17 @@
+use std::fmt::Display;
+
+use super::*;
+
+pub struct NumberLiteral {
+    pub position: TokenPosition,
+    pub value: f64,
+}
+
+impl NumberLiteral {
+    pub fn new(start: usize, end: usize, value: &str) -> Self {
+        NumberLiteral {
+            position: TokenPosition::new(start, end),
+            value: value.parse::<f64>().unwrap(),
+        }
+    }
+}

--- a/Compiler/src/hulk_tokens.rs
+++ b/Compiler/src/hulk_tokens.rs
@@ -1,42 +1,42 @@
 #[derive(Debug, PartialEq)]
 pub enum KeywordToken {
-    PRINT,
-    WHILE,
-    ELIF,
-    ELSE,
-    IF,
-    IN,
-    LET,
-    TRUE,
-    FALSE,
+    Print,
+    While,
+    Elif,
+    Else,
+    If,
+    In,
+    Let,
+    True,
+    False,
 }
 
 #[derive(Debug, PartialEq)]
 pub enum OperatorToken {
-    MUL,
-    DIV,
-    PLUS,
-    MINUS,
-    MOD,
-    POW,
-    NEG,
-    NOT,
-    EQ,
-    NEQ,
-    GT,
-    GTE,
-    LT,
-    LTE,
+    Mul,
+    Div,
+    Plus,
+    Minus,
+    Mod,
+    Pow,
+    Neg,
+    Not,
+    Eq,
+    Neq,
+    Gt,
+    Gte,
+    Lt,
+    Lte,
 }
 
 #[derive(Debug, PartialEq)]
 pub enum DelimiterToken {
-    SEMICOLON,
-    COMMA,
-    LPAREN,
-    RPAREN,
-    LBRACE,
-    RBRACE,
+    Semicolon,
+    Comma,
+    Lparen,
+    Rparen,
+    Lbrace,
+    Rbrace,
 }
 
 #[derive(Debug, PartialEq)]

--- a/Compiler/src/main.rs
+++ b/Compiler/src/main.rs
@@ -1,13 +1,14 @@
 use lalrpop_util::lalrpop_mod;
 mod ast;
+mod hulk_tokens;
 
 lalrpop_mod!(pub parser);
 
 use std::io::{self, Write};
-use crate::parser::ExpParserParser;
+use crate::parser::Expressions_ListParser;
 
 fn main() {
-    let parser = ExpParserParser::new();
+    let parser = Expressions_ListParser::new();
     loop {
         print!("> ");
         io::stdout().flush().unwrap();
@@ -18,11 +19,18 @@ fn main() {
         }
 
         match parser.parse(&input) {
-            Ok(expr) => {   
-                println!("= {}", expr.eval());
-                println!("AST: {:?}", expr);
+            Ok(ast) => {
+            for expr in ast {
+                println!("{}", expr.to_tree(0)); // Mostrar el árbol con sangría
+                match expr.eval() {
+                Ok(result) => println!("Resultado: {}", result),
+                Err(err) => eprintln!("Error: {}", err),
+                }
             }
-            Err(err) => eprintln!("Error de sintaxis: {:?}", err),
+            }
+            Err(err) => {
+            eprintln!("Error de análisis: {}", err);
+            }
         }
     }
 }

--- a/Compiler/src/parser.lalrpop
+++ b/Compiler/src/parser.lalrpop
@@ -1,26 +1,168 @@
-use crate::ast::{Expr};
 use std::str::FromStr;
 
+use crate::ast::Expr;
+use crate::hulk_tokens::*;
 
 grammar;
 
-pub ExpParser: Expr = {
-    <e:Expr> => e
+pub Expressions_List: Vec<Box<Expr>> = {
+    <v:(<Expr> Semicolon)*> => v
 };
 
-Expr: Expr = {
-    <l:Expr> "+" <r:Term> => Expr::Add(Box::new(l), Box::new(r)),
-    <l:Expr> "-" <r:Term> => Expr::Sub(Box::new(l), Box::new(r)),
-    Term,
+Expr: Box<Expr> = { EqualEqualExpr };
+
+EqualEqualExpr: Box<Expr> = {
+    <left:ComparisonExpr> <rest:(EqualOp ComparisonExpr)*> => {
+        rest.into_iter().fold(left, |l, (op, r)| {
+            Box::new(Expr::BinaryOp(l, op, r))
+        })
+    }
 };
 
-Term: Expr = {
-    <l:Term> "*" <r:Factor> => Expr::Mul(Box::new(l), Box::new(r)),
-    <l:Term> "/" <r:Factor> => Expr::Div(Box::new(l), Box::new(r)),
-    Factor,
+EqualOp: OperatorToken = {
+    "==" => OperatorToken::Eq,
+    "!=" => OperatorToken::Neq,
 };
 
-Factor: Expr = {
-    r"[0-9]+" => Expr::Number(i64::from_str(<>).unwrap()),
-    "(" <e:Expr> ")" => e,
+ComparisonExpr: Box<Expr> = {
+    <left:TermExpr> <rest:(ComparisonOp TermExpr)*> => {
+        rest.into_iter().fold(left, |l, (op, r)| {
+            Box::new(Expr::BinaryOp(l, op, r))
+        })
+    }
+};
+
+ComparisonOp: OperatorToken = {
+    ">" => OperatorToken::Gt,
+    ">=" => OperatorToken::Gte,
+    "<" => OperatorToken::Lt,
+    "<=" => OperatorToken::Lte,
+};
+
+TermExpr: Box<Expr> = {
+    <left:FactorExpr> <rest:(TermOp FactorExpr)*> => {
+        rest.into_iter().fold(left, |l, (op, r)| {
+            Box::new(Expr::BinaryOp(l, op, r))
+        })
+    }
+};
+
+TermOp: OperatorToken = {
+    "+" => OperatorToken::Plus,
+    "-" => OperatorToken::Minus,
+};
+
+FactorExpr: Box<Expr> = {
+    <left:ExponentExpr> <rest:(FactorOp ExponentExpr)*> => {
+        rest.into_iter().fold(left, |l, (op, r)| {
+            Box::new(Expr::BinaryOp(l, op, r))
+        })
+    }
+};
+
+FactorOp: OperatorToken = {
+    "*" => OperatorToken::Mul,
+    "/" => OperatorToken::Div,
+    "%" => OperatorToken::Mod,
+};
+
+ExponentExpr: Box<Expr> = {
+    <left:UnaryExpr> <op:PowOp> <right:ExponentExpr> => Box::new(Expr::BinaryOp(left, op, right)),
+    UnaryExpr,
+};
+
+PowOp: OperatorToken = {
+    "^" => OperatorToken::Pow,
+};
+
+UnaryExpr: Box<Expr> = {
+    <op:UnaryOp> <expr:UnaryExpr> => Box::new(Expr::UnaryOp(op, expr)),
+    PrimaryExpr,
+};
+
+UnaryOp: OperatorToken = {
+    "!" => OperatorToken::Not,
+    "-" => OperatorToken::Neg,
+};
+
+PrimaryExpr: Box<Expr> = {
+    Num => Box::new(Expr::Number(<>)),
+    Str => Box::new(Expr::Str(<>)),
+    Identifier => Box::new(Expr::Identifier(<>)),
+    LParen <Expr> RParen => Box::new(*<>),
+    PrintExpr,
+    True => Box::new(Expr::Boolean(true)),
+    False => Box::new(Expr::Boolean(false)),
+};
+
+PrintExpr: Box<Expr> = {
+    Print LParen <Expr> RParen => Box::new(Expr::Print(<>)),
+};
+
+Semicolon: DelimiterToken = {
+    ";" => DelimiterToken::Semicolon,
+};
+
+RParen: DelimiterToken = {
+    ")" => DelimiterToken::Rparen,
+};
+
+LParen: DelimiterToken = {
+    "(" => DelimiterToken::Lparen,
+};
+
+RBrace: DelimiterToken = {
+    "}" => DelimiterToken::Rbrace,
+};
+
+LBrace: DelimiterToken = {
+    "{" => DelimiterToken::Lbrace,
+};
+
+Let: KeywordToken = {
+    "let" => KeywordToken::Let,
+};
+
+Else: KeywordToken = {
+    "else" => KeywordToken::Else,
+};
+
+Elif: KeywordToken = {
+    "elif" => KeywordToken::Elif,
+};
+
+In: KeywordToken = {
+    "in" => KeywordToken::In,
+};
+
+If: KeywordToken = {
+    "if" => KeywordToken::If,
+};
+
+While: KeywordToken = {
+    "while" => KeywordToken::While,
+};
+
+Print: KeywordToken = {
+    "print" => KeywordToken::Print,
+};
+
+True: KeywordToken = {
+    "true" => KeywordToken::True,
+};
+
+False: KeywordToken = {
+    "false" => KeywordToken::False,
+};
+
+Identifier: String = {
+    r"[A-Za-z][A-Za-z_0-9]*" => String::from_str(<>).unwrap(),
+};
+
+Num: i32 = {
+    r"[0-9]+(\.[0-9]+)?" => i32::from_str(<>).unwrap(),
+};
+
+Str: String = {
+    r#""([^"\\]|\\.)*""# => String::from_str(&<>[1..<>.len()-1]).unwrap(),
 };

--- a/Compiler/src/token_pos.rs
+++ b/Compiler/src/token_pos.rs
@@ -1,0 +1,11 @@
+#[derive(Copy, Clone)]
+pub struct TokenPosition {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl TokenPosition {
+    pub fn new(start: usize, end: usize) -> Self {
+        TokenPosition { start, end }
+    }
+}


### PR DESCRIPTION
This pull request introduces significant enhancements to the compiler's abstract syntax tree (AST), token handling, and parser functionality. Key changes include expanding the `Expr` enum to support more expression types, improving error handling in evaluation, introducing position tracking for tokens, and overhauling the parser to support a richer grammar.

### AST Enhancements
* Updated the `Expr` enum in `Compiler/src/ast.rs` to include new expression types (e.g., `Boolean`, `Str`, `Identifier`, `BinaryOp`, `UnaryOp`, `Print`) and improved the `eval` method to handle these types with better error handling. Added a `to_tree` method for visualizing the AST.

### Token and Literal Handling
* Introduced a new `Identifier` struct in `Compiler/src/hulk_idenfitifer.rs` and `NumberLiteral` struct in `Compiler/src/hulk_literal.rs` to represent identifiers and numeric literals with position tracking. [[1]](diffhunk://#diff-c74a0aa479f123b69b239ef0beb04b06b454e8b9252a4fd49ba770ec331310beR1-R20) [[2]](diffhunk://#diff-dd6af828af7297c4ec12d7e21762103bb55efbc79cbf0b971c52072d92dbed30R1-R17)
* Renamed `hulkTokens.rs` to `hulk_tokens.rs` and updated token enums (e.g., `KeywordToken`, `OperatorToken`, `DelimiterToken`) to use PascalCase for consistency.

### Parser Overhaul
* Replaced the old parser rule `ExpParser` with `Expressions_List` in `Compiler/src/parser.lalrpop`, introducing a more expressive grammar for binary, unary, and comparison operators, as well as support for keywords like `print`, `if`, and `while`.

### Main Function Updates
* Updated `fn main` in `Compiler/src/main.rs` to parse and evaluate multiple expressions, display the AST using the new `to_tree` method, and handle evaluation errors gracefully.

### Token Position Tracking
* Added a `TokenPosition` struct in `Compiler/src/token_pos.rs` to track the start and end positions of tokens, enabling better error reporting and debugging.