### PR TITLE
Codegen abraham

### DIFF
--- a/Compiler/src/codegen/context.rs
+++ b/Compiler/src/codegen/context.rs
@@ -22,8 +22,8 @@ impl CodegenContext {
     }
 
     pub fn generate_label(&mut self, base: &str) -> String {
-        let label = format!("{}{}", base, self.temp_count);
-        self.temp_count += 1;
+        let label = format!("{}{}", base, self.temp_counter);
+        self.temp_counter += 1;
         label
     }
 

--- a/Compiler/src/codegen/context.rs
+++ b/Compiler/src/codegen/context.rs
@@ -31,4 +31,20 @@ impl CodegenContext {
         self.code.push_str(line);
         self.code.push('\n');
     }
+
+    pub fn emit_global(&mut self, line: &str) {
+        self.code.push_str(line);
+        self.code.push('\n');
+    }
+
+    pub fn register_variable(&mut self, name: &str, reg: String) {
+        self.symbol_table.insert(name.to_string(), reg);
+    }
+
+    // Si necesitas manejar strings constantes en LLVM IR, implementa este método
+    pub fn generate_string_const_name(&mut self) -> String {
+        let name = format!(".str.{}", self.temp_counter);
+        self.temp_counter += 1;
+        name
+    }
 }

--- a/Compiler/src/codegen/llvm_runner.rs
+++ b/Compiler/src/codegen/llvm_runner.rs
@@ -1,5 +1,5 @@
 use std::process::Command;
-use std::env;
+// use std::env;
 
 pub fn run_llvm_ir(filename: &str) {
     let (output, clang_args): (&str, Vec<&str>) = if cfg!(target_os = "windows") {
@@ -7,7 +7,8 @@ pub fn run_llvm_ir(filename: &str) {
             "output.exe",
             vec![
                 filename,
-                "-o", "output.exe",
+                "-o",
+                "output.exe",
                 "-fuse-ld=lld",
                 "--target=x86_64-w64-windows-gnu",
             ],
@@ -17,7 +18,8 @@ pub fn run_llvm_ir(filename: &str) {
             "output_macos",
             vec![
                 filename,
-                "-o", "output_macos",
+                "-o",
+                "output_macos",
                 "-fuse-ld=lld",
                 "--target=x86_64-apple-darwin",
             ],
@@ -28,7 +30,8 @@ pub fn run_llvm_ir(filename: &str) {
             "output_linux",
             vec![
                 filename,
-                "-o", "output_linux",
+                "-o",
+                "output_linux",
                 "-fuse-ld=lld",
                 "--target=x86_64-pc-linux-gnu",
             ],

--- a/Compiler/src/hulk_Tokens/hulk_assignment.rs
+++ b/Compiler/src/hulk_Tokens/hulk_assignment.rs
@@ -1,11 +1,9 @@
 use super::hulk_identifier::Identifier;
+use crate::codegen::context::CodegenContext;
+use crate::codegen::traits::Codegen;
 use crate::hulk_tokens::hulk_expression::Expr;
 use crate::visitor::hulk_accept::Accept;
 use crate::visitor::hulk_visitor::Visitor;
-use crate::codegen::traits::Codegen;
-use crate::codegen::context::CodegenContext;
-
-
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Assignment {
@@ -15,11 +13,12 @@ pub struct Assignment {
 
 impl Assignment {
     pub fn new(identifier: Identifier, expression: Box<Expr>) -> Self {
-        Assignment { identifier, expression }
+        Assignment {
+            identifier,
+            expression,
+        }
     }
 }
-
-
 
 impl Accept for Assignment {
     fn accept<V: Visitor<T>, T>(&self, visitor: &mut V) -> T {
@@ -29,7 +28,19 @@ impl Accept for Assignment {
 
 impl Codegen for Assignment {
     fn codegen(&self, context: &mut CodegenContext) -> String {
-        // TODO: Implement codegen for Assignment
-        String::new()
+        // Busca el puntero de la variable en la tabla de símbolos
+        let var_name = &self.identifier.id;
+        if let Some(ptr) = context.symbol_table.get(var_name) {
+            // Genera el valor de la expresión
+            let value_reg = self.expression.codegen(context);
+            // Emite la instrucción de almacenamiento
+            context.emit(&format!("  store i32 {}, i32* {}", value_reg, ptr));
+            value_reg
+        } else {
+            panic!(
+                "Variable '{}' no definida en el contexto para asignación",
+                var_name
+            );
+        }
     }
 }

--- a/Compiler/src/hulk_Tokens/hulk_assignment.rs
+++ b/Compiler/src/hulk_Tokens/hulk_assignment.rs
@@ -28,12 +28,10 @@ impl Accept for Assignment {
 
 impl Codegen for Assignment {
     fn codegen(&self, context: &mut CodegenContext) -> String {
-        // Busca el puntero de la variable en la tabla de símbolos
         let var_name = &self.identifier.id;
-        if let Some(ptr) = context.symbol_table.get(var_name) {
-            // Genera el valor de la expresión
+        let ptr = context.symbol_table.get(var_name).cloned();
+        if let Some(ptr) = ptr {
             let value_reg = self.expression.codegen(context);
-            // Emite la instrucción de almacenamiento
             context.emit(&format!("  store i32 {}, i32* {}", value_reg, ptr));
             value_reg
         } else {

--- a/Compiler/src/hulk_Tokens/hulk_code_block.rs
+++ b/Compiler/src/hulk_Tokens/hulk_code_block.rs
@@ -1,6 +1,6 @@
-use crate::hulk_tokens::hulk_expression::Expr;
-use crate::codegen::traits::Codegen;
 use crate::codegen::context::CodegenContext;
+use crate::codegen::traits::Codegen;
+use crate::hulk_tokens::hulk_expression::Expr;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct ExpressionList {
@@ -17,8 +17,11 @@ impl ExpressionList {
 
 impl Codegen for ExpressionList {
     fn codegen(&self, context: &mut CodegenContext) -> String {
-        // TODO: Implement codegen for ExpressionList
-        String::new()
+        let mut last_reg = String::new();
+        for expr in self.expressions.iter() {
+            last_reg = expr.codegen(context);
+        }
+        last_reg
     }
 }
 
@@ -30,14 +33,18 @@ pub struct Block {
 impl Block {
     pub fn new(expression_list: ExpressionList) -> Self {
         Block {
-            expression_list: Box::new(expression_list)
+            expression_list: Box::new(expression_list),
         }
     }
 }
 
 impl Codegen for Block {
     fn codegen(&self, context: &mut CodegenContext) -> String {
-        // TODO: Implement codegen for Block
-        String::new()
+        let exprs = &self.expression_list.expressions;
+        let mut last_reg = String::new();
+        for expr in exprs.iter() {
+            last_reg = expr.codegen(context);
+        }
+        last_reg
     }
 }

--- a/Compiler/src/hulk_Tokens/hulk_destructive_assign.rs
+++ b/Compiler/src/hulk_Tokens/hulk_destructive_assign.rs
@@ -1,8 +1,8 @@
-use crate ::hulk_tokens::hulk_expression::Expr;
-use crate::codegen::traits::Codegen;
 use crate::codegen::context::CodegenContext;
+use crate::codegen::traits::Codegen;
+use crate::hulk_tokens::hulk_expression::Expr;
 
-#[derive(Debug, PartialEq,Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct DestructiveAssignment {
     pub identifier: String,
     pub expression: Box<Expr>,
@@ -19,7 +19,19 @@ impl DestructiveAssignment {
 
 impl Codegen for DestructiveAssignment {
     fn codegen(&self, context: &mut CodegenContext) -> String {
-        // TODO: Implement codegen for DestructiveAssignment
-        String::new()
+        // Busca el puntero de la variable en la tabla de símbolos
+        let var_name = &self.identifier;
+        if let Some(ptr) = context.symbol_table.get(var_name) {
+            // Genera el valor de la expresión
+            let value_reg = self.expression.codegen(context);
+            // Emite la instrucción de almacenamiento
+            context.emit(&format!("  store i32 {}, i32* {}", value_reg, ptr));
+            value_reg
+        } else {
+            panic!(
+                "Variable '{}' no definida en el contexto para asignación destructiva",
+                var_name
+            );
+        }
     }
 }

--- a/Compiler/src/hulk_Tokens/hulk_destructive_assign.rs
+++ b/Compiler/src/hulk_Tokens/hulk_destructive_assign.rs
@@ -19,12 +19,10 @@ impl DestructiveAssignment {
 
 impl Codegen for DestructiveAssignment {
     fn codegen(&self, context: &mut CodegenContext) -> String {
-        // Busca el puntero de la variable en la tabla de símbolos
         let var_name = &self.identifier;
-        if let Some(ptr) = context.symbol_table.get(var_name) {
-            // Genera el valor de la expresión
+        let ptr = context.symbol_table.get(var_name).cloned();
+        if let Some(ptr) = ptr {
             let value_reg = self.expression.codegen(context);
-            // Emite la instrucción de almacenamiento
             context.emit(&format!("  store i32 {}, i32* {}", value_reg, ptr));
             value_reg
         } else {

--- a/Compiler/src/hulk_Tokens/hulk_expression.rs
+++ b/Compiler/src/hulk_Tokens/hulk_expression.rs
@@ -1,21 +1,20 @@
-use crate::hulk_tokens::hulk_operators::*;
-use crate::hulk_tokens::hulk_assignment::Assignment;
-use crate::hulk_tokens::hulk_literal::*;
-use crate::hulk_tokens::hulk_identifier::*;
-use crate::hulk_tokens::hulk_ifExp::*;
-use crate::hulk_tokens::hulk_binary_expr::*;
-use crate::hulk_tokens::hulk_unary_expr::*;
-use crate::hulk_tokens::hulk_let_in::*;
-use crate::hulk_tokens::hulk_whileloop::*;
-use crate::hulk_tokens::hulk_for_expr::ForExpr;
+use crate::codegen::context::CodegenContext;
+use crate::codegen::traits::Codegen;
 use crate::hulk_tokens::Block;
 use crate::hulk_tokens::DestructiveAssignment;
+use crate::hulk_tokens::FunctionCall;
+use crate::hulk_tokens::hulk_assignment::Assignment;
+use crate::hulk_tokens::hulk_binary_expr::*;
+use crate::hulk_tokens::hulk_for_expr::ForExpr;
+use crate::hulk_tokens::hulk_identifier::*;
+use crate::hulk_tokens::hulk_ifExp::*;
+use crate::hulk_tokens::hulk_let_in::*;
+use crate::hulk_tokens::hulk_literal::*;
+use crate::hulk_tokens::hulk_operators::*;
+use crate::hulk_tokens::hulk_unary_expr::*;
+use crate::hulk_tokens::hulk_whileloop::*;
 use crate::visitor::hulk_accept::Accept;
 use crate::visitor::hulk_visitor::Visitor;
-use crate::hulk_tokens::FunctionCall;
-use crate::codegen::traits::Codegen;
-use crate::codegen::context::CodegenContext;
-
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Expr {
@@ -44,9 +43,8 @@ pub enum ExprKind {
     WhileLoop(WhileLoop),
     ForExp(ForExpr),
     CodeBlock(Block),
-    DestructiveAssign(DestructiveAssignment)
+    DestructiveAssign(DestructiveAssignment),
 }
-
 
 impl Expr {
     pub fn new(kind: ExprKind) -> Self {
@@ -97,7 +95,7 @@ impl Expr {
 }
 
 impl Accept for ExprKind {
-    fn accept<V: Visitor<T>,T>(&self, visitor: &mut V) -> T {
+    fn accept<V: Visitor<T>, T>(&self, visitor: &mut V) -> T {
         match self {
             ExprKind::Number(node) => visitor.visit_number_literal(node),
             ExprKind::Boolean(node) => visitor.visit_boolean_literal(node),
@@ -119,14 +117,27 @@ impl Accept for ExprKind {
 
 impl Codegen for Expr {
     fn codegen(&self, context: &mut CodegenContext) -> String {
-        // TODO: Implement codegen for Expr
-        String::new()
+        self.kind.codegen(context)
     }
 }
 
 impl Codegen for ExprKind {
     fn codegen(&self, context: &mut CodegenContext) -> String {
-        // TODO: Implement codegen for ExprKind
-        String::new()
+        match self {
+            ExprKind::Number(n) => n.codegen(context),
+            ExprKind::Boolean(b) => b.codegen(context),
+            ExprKind::String(s) => s.codegen(context),
+            ExprKind::Identifier(id) => id.codegen(context),
+            ExprKind::BinaryOp(bin) => bin.codegen(context),
+            ExprKind::UnaryOp(un) => un.codegen(context),
+            ExprKind::If(ifexp) => ifexp.codegen(context),
+            ExprKind::FunctionCall(call) => call.codegen(context),
+            ExprKind::Assignment(assign) => assign.codegen(context),
+            ExprKind::LetIn(letin) => letin.codegen(context),
+            ExprKind::WhileLoop(whileloop) => whileloop.codegen(context),
+            ExprKind::ForExp(forexp) => forexp.codegen(context),
+            ExprKind::CodeBlock(block) => block.codegen(context),
+            ExprKind::DestructiveAssign(destruct) => destruct.codegen(context),
+        }
     }
 }

--- a/Compiler/src/hulk_Tokens/hulk_function_call.rs
+++ b/Compiler/src/hulk_Tokens/hulk_function_call.rs
@@ -1,22 +1,43 @@
-use crate::hulk_tokens::hulk_expression::Expr;
-use crate::codegen::traits::Codegen;
 use crate::codegen::context::CodegenContext;
+use crate::codegen::traits::Codegen;
+use crate::hulk_tokens::hulk_expression::Expr;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct FunctionCall {
-    pub funct_name: String,             
+    pub funct_name: String,
     pub arguments: Vec<Expr>,
 }
 
 impl FunctionCall {
     pub fn new(funct_name: String, arguments: Vec<Expr>) -> Self {
-        FunctionCall { funct_name, arguments }
+        FunctionCall {
+            funct_name,
+            arguments,
+        }
     }
 }
 
 impl Codegen for FunctionCall {
     fn codegen(&self, context: &mut CodegenContext) -> String {
-        // TODO: Implement codegen for FunctionCall
-        String::new()
+        // Genera el código para cada argumento y obtiene los registros
+        let arg_regs: Vec<String> = self
+            .arguments
+            .iter()
+            .map(|arg| arg.codegen(context))
+            .collect();
+        // Prepara la lista de argumentos para LLVM IR (asume i32 para todos)
+        let args_str = arg_regs
+            .iter()
+            .map(|reg| format!("i32 {}", reg))
+            .collect::<Vec<_>>()
+            .join(", ");
+        // Obtiene un nuevo registro temporal para el resultado
+        let result_reg = context.generate_temp();
+        // Emite la instrucción de llamada
+        context.emit(&format!(
+            "  {} = call i32 @{}({})",
+            result_reg, self.funct_name, args_str
+        ));
+        result_reg
     }
 }

--- a/Compiler/src/hulk_Tokens/hulk_function_def.rs
+++ b/Compiler/src/hulk_Tokens/hulk_function_def.rs
@@ -57,7 +57,7 @@ impl Codegen for FunctionParams {
         // Almacena el argumento en el espacio local
         context.emit(&format!("  store i32 {}, i32* {}", arg_name, alloca_reg));
         // Registra el parámetro en la tabla de símbolos
-        context.register_variable(&self.name, alloca_reg);
+        context.register_variable(&self.name, alloca_reg.clone());
         alloca_reg
     }
 }

--- a/Compiler/src/hulk_Tokens/hulk_function_def.rs
+++ b/Compiler/src/hulk_Tokens/hulk_function_def.rs
@@ -1,10 +1,10 @@
 use std::fmt;
 
-use crate::hulk_tokens::hulk_expression::Expr;
-use crate::codegen::traits::Codegen;
 use crate::codegen::context::CodegenContext;
+use crate::codegen::traits::Codegen;
+use crate::hulk_tokens::hulk_expression::Expr;
 
-#[derive(Debug, PartialEq,Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct FunctionParams {
     pub name: String,
     pub signature: String,
@@ -12,10 +12,7 @@ pub struct FunctionParams {
 
 impl FunctionParams {
     pub fn new(name: String, signature: String) -> Self {
-        FunctionParams {
-            name,
-            signature,
-        }
+        FunctionParams { name, signature }
     }
 }
 
@@ -35,7 +32,12 @@ pub struct FunctionDef {
 }
 
 impl FunctionDef {
-    pub fn new_expr(name: String, params: Vec<FunctionParams>, return_type: String, expr: Box<Expr>) -> Self {
+    pub fn new_expr(
+        name: String,
+        params: Vec<FunctionParams>,
+        return_type: String,
+        expr: Box<Expr>,
+    ) -> Self {
         FunctionDef {
             name,
             params,
@@ -47,14 +49,40 @@ impl FunctionDef {
 
 impl Codegen for FunctionParams {
     fn codegen(&self, context: &mut CodegenContext) -> String {
-        // TODO: Implement codegen for FunctionParams
-        String::new()
+        // Genera un nombre de argumento LLVM (por ejemplo, %x)
+        let arg_name = format!("%{}", self.name);
+        // Reserva espacio local para el argumento
+        let alloca_reg = context.generate_temp();
+        context.emit(&format!("  {} = alloca i32", alloca_reg));
+        // Almacena el argumento en el espacio local
+        context.emit(&format!("  store i32 {}, i32* {}", arg_name, alloca_reg));
+        // Registra el parámetro en la tabla de símbolos
+        context.register_variable(&self.name, alloca_reg);
+        alloca_reg
     }
 }
 
 impl Codegen for FunctionDef {
     fn codegen(&self, context: &mut CodegenContext) -> String {
-        // TODO: Implement codegen for FunctionDef
-        String::new()
+        // Prepara la lista de parámetros para LLVM IR
+        let params_ir: Vec<String> = self
+            .params
+            .iter()
+            .map(|p| format!("i32 %{}", p.name))
+            .collect();
+        let params_str = params_ir.join(", ");
+        // Cabecera de la función
+        context.emit(&format!("define i32 @{}({}) {{", self.name, params_str));
+        // Prologo: asigna espacio y almacena los argumentos
+        for param in &self.params {
+            param.codegen(context);
+        }
+        // Genera el cuerpo de la función
+        let ret_val = self.body.codegen(context);
+        // Retorno
+        context.emit(&format!("  ret i32 {}", ret_val));
+        // Cierre de la función
+        context.emit("}");
+        String::new() // No se usa el valor de retorno
     }
 }

--- a/Compiler/src/hulk_Tokens/hulk_function_info.rs
+++ b/Compiler/src/hulk_Tokens/hulk_function_info.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
-use crate::typings::types_node::TypeNode;
-use crate::codegen::traits::Codegen;
 use crate::codegen::context::CodegenContext;
+use crate::codegen::traits::Codegen;
+use crate::typings::types_node::TypeNode;
+use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
 pub struct HulkFunctionInfo {
@@ -11,7 +11,11 @@ pub struct HulkFunctionInfo {
 }
 
 impl HulkFunctionInfo {
-    pub fn new(function_name: String, argument_types: Vec<TypeNode>, return_type: TypeNode) -> Self {
+    pub fn new(
+        function_name: String,
+        argument_types: Vec<TypeNode>,
+        return_type: TypeNode,
+    ) -> Self {
         HulkFunctionInfo {
             function_name,
             argument_types,
@@ -22,7 +26,18 @@ impl HulkFunctionInfo {
 
 impl Codegen for HulkFunctionInfo {
     fn codegen(&self, context: &mut CodegenContext) -> String {
-        // TODO: Implement codegen for HulkFunctionInfo
+        // Genera el prototipo de la función en LLVM IR
+        // Convierte los tipos de argumentos y retorno a LLVM (asume i32 por simplicidad)
+        let args_ir: Vec<String> = self
+            .argument_types
+            .iter()
+            .map(|_| "i32".to_string())
+            .collect();
+        let args_str = args_ir.join(", ");
+        let ret_type = "i32"; // Puedes mapear self.return_type a LLVM IR si tienes más tipos
+        // Emite la declaración del prototipo (sin cuerpo)
+        let proto = format!("declare {} @{}({})", ret_type, self.function_name, args_str);
+        context.emit_global(&proto);
         String::new()
     }
 }

--- a/Compiler/src/hulk_Tokens/hulk_identifier.rs
+++ b/Compiler/src/hulk_Tokens/hulk_identifier.rs
@@ -1,6 +1,6 @@
-use std::fmt;
-use crate::codegen::traits::Codegen;
 use crate::codegen::context::CodegenContext;
+use crate::codegen::traits::Codegen;
+use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Identifier {
@@ -9,11 +9,8 @@ pub struct Identifier {
 
 impl Identifier {
     pub fn new(id: &str) -> Self {
-        Self {
-            id: id.to_string(),
-        }
+        Self { id: id.to_string() }
     }
-
 }
 
 impl fmt::Display for Identifier {
@@ -24,7 +21,15 @@ impl fmt::Display for Identifier {
 
 impl Codegen for Identifier {
     fn codegen(&self, context: &mut CodegenContext) -> String {
-        // TODO: Implement codegen for Identifier
-        String::new()
+        // Busca el puntero de la variable en la tabla de símbolos
+        if let Some(ptr) = context.symbol_table.get(&self.id) {
+            let result_reg = context.generate_temp();
+            // Asume tipo i32 (ajustar si soportas otros tipos)
+            let line = format!("  {} = load i32, i32* {}", result_reg, ptr);
+            context.emit(&line);
+            result_reg
+        } else {
+            panic!("Variable '{}' no definida en el contexto", self.id);
+        }
     }
 }

--- a/Compiler/src/hulk_Tokens/hulk_identifier.rs
+++ b/Compiler/src/hulk_Tokens/hulk_identifier.rs
@@ -22,7 +22,8 @@ impl fmt::Display for Identifier {
 impl Codegen for Identifier {
     fn codegen(&self, context: &mut CodegenContext) -> String {
         // Busca el puntero de la variable en la tabla de símbolos
-        if let Some(ptr) = context.symbol_table.get(&self.id) {
+        let ptr = context.symbol_table.get(&self.id).cloned();
+        if let Some(ptr) = ptr {
             let result_reg = context.generate_temp();
             // Asume tipo i32 (ajustar si soportas otros tipos)
             let line = format!("  {} = load i32, i32* {}", result_reg, ptr);

--- a/Compiler/src/hulk_Tokens/hulk_let_in.rs
+++ b/Compiler/src/hulk_Tokens/hulk_let_in.rs
@@ -1,10 +1,10 @@
-use crate::hulk_tokens::hulk_expression::Expr;
+use crate::codegen::context::CodegenContext;
+use crate::codegen::traits::Codegen;
 use crate::hulk_tokens::hulk_assignment::Assignment;
+use crate::hulk_tokens::hulk_expression::Expr;
 use crate::hulk_tokens::hulk_keywords::KeywordToken;
 use crate::visitor::hulk_accept::Accept;
 use crate::visitor::hulk_visitor::Visitor;
-use crate::codegen::traits::Codegen;
-use crate::codegen::context::CodegenContext;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct LetIn {
@@ -18,10 +18,15 @@ impl LetIn {
     pub fn new(
         let_token: KeywordToken,
         assignment: Vec<Assignment>,
-        in_keyword: KeywordToken, 
-        body: Box<Expr>
+        in_keyword: KeywordToken,
+        body: Box<Expr>,
     ) -> Self {
-        LetIn { let_token, assignment, in_keyword, body }
+        LetIn {
+            let_token,
+            assignment,
+            in_keyword,
+            body,
+        }
     }
 }
 
@@ -31,8 +36,8 @@ impl Codegen for LetIn {
         let mut previous_bindings: Vec<(String, Option<String>)> = vec![];
 
         for assignment in &self.assignment {
-            let name = assignment.identifier.clone();
-            let value_expr = &assignment.value;
+            let name = assignment.identifier.id.clone();
+            let value_expr = &assignment.expression;
 
             let value_reg = value_expr.codegen(context);
 

--- a/Compiler/src/hulk_Tokens/hulk_program.rs
+++ b/Compiler/src/hulk_Tokens/hulk_program.rs
@@ -1,5 +1,5 @@
-use crate::codegen::traits::Codegen;
 use crate::codegen::context::CodegenContext;
+use crate::codegen::traits::Codegen;
 use crate::hulk_tokens::hulk_expression::Expr;
 use crate::visitor::hulk_accept::Accept;
 use crate::visitor::hulk_visitor::Visitor;
@@ -13,17 +13,21 @@ pub struct ProgramNode {
 
 impl ProgramNode {
     pub fn new(instructions: Vec<Instruction>) -> Self {
-        ProgramNode { instructions: instructions }
+        ProgramNode {
+            instructions: instructions,
+        }
     }
-    pub fn with_instructions(pre: Vec<Instruction>, expr: Box<Expr>, post: Vec<Instruction>) -> Self {
+    pub fn with_instructions(
+        pre: Vec<Instruction>,
+        expr: Box<Expr>,
+        post: Vec<Instruction>,
+    ) -> Self {
         let mut instructions = pre;
         instructions.push(Instruction::Expression(expr));
         instructions.extend(post);
         ProgramNode { instructions }
     }
-
 }
-
 
 impl Accept for ProgramNode {
     fn accept<V: Visitor<T>, T>(&self, visitor: &mut V) -> T {
@@ -31,15 +35,13 @@ impl Accept for ProgramNode {
     }
 }
 
-
 #[derive(Debug, Clone)]
 pub enum Instruction {
-//    Class(ClassDecl),
-   FunctionDef(FunctionDef),
-//    Protocol(ProtocolDecl),
-   Expression(Box<Expr>)
+    //    Class(ClassDecl),
+    FunctionDef(FunctionDef),
+    //    Protocol(ProtocolDecl),
+    Expression(Box<Expr>),
 }
-
 
 impl Instruction {
     pub fn eval(&self) -> Result<f64, String> {
@@ -54,21 +56,26 @@ impl Accept for Instruction {
     fn accept<V: Visitor<T>, T>(&self, visitor: &mut V) -> T {
         match self {
             Instruction::Expression(expr) => expr.accept(visitor),
-            Instruction::FunctionDef(func_def) => visitor.visit_function_def(func_def)
+            Instruction::FunctionDef(func_def) => visitor.visit_function_def(func_def),
         }
     }
 }
 
 impl Codegen for ProgramNode {
     fn codegen(&self, context: &mut CodegenContext) -> String {
-        // TODO: Implement codegen for ProgramNode
-        String::new()
+        let mut last_reg = String::new();
+        for instr in &self.instructions {
+            last_reg = instr.codegen(context);
+        }
+        last_reg
     }
 }
 
 impl Codegen for Instruction {
     fn codegen(&self, context: &mut CodegenContext) -> String {
-        // TODO: Implement codegen for Instruction
-        String::new()
+        match self {
+            Instruction::FunctionDef(func_def) => func_def.codegen(context),
+            Instruction::Expression(expr) => expr.codegen(context),
+        }
     }
 }

--- a/Compiler/src/hulk_Tokens/hulk_unary_expr.rs
+++ b/Compiler/src/hulk_Tokens/hulk_unary_expr.rs
@@ -1,7 +1,7 @@
-use crate::hulk_tokens::hulk_expression::Expr;
 use super::hulk_operators::UnaryOperator;
-use crate::codegen::traits::Codegen;
 use crate::codegen::context::CodegenContext;
+use crate::codegen::traits::Codegen;
+use crate::hulk_tokens::hulk_expression::Expr;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct UnaryExpr {
@@ -16,8 +16,33 @@ impl UnaryExpr {
 
 impl Codegen for UnaryExpr {
     fn codegen(&self, context: &mut CodegenContext) -> String {
-        // TODO: Implement codegen for UnaryExpr
-        String::new()
+        // Genera el código del operando
+        let operand_reg = self.operand.codegen(context);
+
+        // Obtiene un nuevo registro temporal
+        let result_reg = context.generate_temp();
+
+        // Selecciona la operación LLVM correspondiente
+        let line = match self.operator {
+            UnaryOperator::Minus => {
+                // Negación aritmética: -x
+                format!("  {} = sub i32 0, {}", result_reg, operand_reg)
+            }
+            UnaryOperator::LogicalNot => {
+                // Negación lógica: !x (bitwise not)
+                format!("  {} = xor i32 {}, -1", result_reg, operand_reg)
+            }
+            UnaryOperator::Plus => {
+                // Operador + unario: simplemente copia el valor
+                format!("  {} = add i32 0, {}", result_reg, operand_reg)
+            }
+            // Puedes agregar más operadores aquí si los tienes definidos
+            _ => panic!("Operador unario no soportado en Codegen"),
+        };
+
+        // Emite la instrucción LLVM IR
+        context.emit(&line);
+
+        result_reg
     }
 }
-

--- a/Compiler/src/hulk_Tokens/hulk_whileloop.rs
+++ b/Compiler/src/hulk_Tokens/hulk_whileloop.rs
@@ -1,6 +1,6 @@
-use crate::hulk_tokens::hulk_expression::Expr;
-use crate::codegen::traits::Codegen;
 use crate::codegen::context::CodegenContext;
+use crate::codegen::traits::Codegen;
+use crate::hulk_tokens::hulk_expression::Expr;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct WhileLoop {
@@ -10,16 +10,40 @@ pub struct WhileLoop {
 
 impl WhileLoop {
     pub fn new(condition: Box<Expr>, body: Box<Expr>) -> Self {
-        Self {
-            condition,
-            body,
-        }
+        Self { condition, body }
     }
 }
 
 impl Codegen for WhileLoop {
     fn codegen(&self, context: &mut CodegenContext) -> String {
-        // TODO: Implement codegen for WhileLoop
-        String::new()
+        // Genera etiquetas únicas
+        let start_label = context.generate_label("while_start");
+        let body_label = context.generate_label("while_body");
+        let end_label = context.generate_label("while_end");
+
+        // Salto incondicional al inicio del bucle
+        context.emit(&format!("  br label %{}", start_label));
+
+        // Etiqueta de inicio
+        context.emit(&format!("{}:", start_label));
+        let cond_reg = self.condition.codegen(context);
+        // Salto condicional al cuerpo o al final
+        context.emit(&format!(
+            "  br i1 {}, label %{}, label %{}",
+            cond_reg, body_label, end_label
+        ));
+
+        // Etiqueta del cuerpo
+        context.emit(&format!("{}:", body_label));
+        let body_reg = self.body.codegen(context);
+        // Al terminar el cuerpo, vuelve a evaluar la condición
+        context.emit(&format!("  br label %{}", start_label));
+
+        // Etiqueta de fin
+        context.emit(&format!("{}:", end_label));
+        // El valor de un while como expresión suele ser 0 (o unit), aquí devolvemos 0
+        let result_reg = context.generate_temp();
+        context.emit(&format!("  {} = add i32 0, 0", result_reg));
+        result_reg
     }
 }


### PR DESCRIPTION
This pull request introduces significant updates to the `Compiler` module, focusing on enhancing code generation functionality and improving code structure. The changes include implementing code generation for various AST nodes, refactoring constructors, and adding new methods for LLVM IR generation. Below is a categorized summary of the most important changes.

### Code Generation Enhancements:
* Implemented `codegen` for `Assignment`, generating LLVM IR for variable assignment and handling undefined variables.
* Added `codegen` for `FunctionCall`, generating LLVM IR for function calls with argument handling and temporary registers.
* Implemented `codegen` for `FunctionDef`, including LLVM IR for function headers, parameter handling, and return values.
* Enhanced `codegen` for `ExprKind`, supporting multiple expression types such as binary operations, function calls, and code blocks.
* Added `codegen` for `HulkFunctionInfo`, generating LLVM IR prototypes for function declarations.

### Structural and Refactoring Improvements:
* Refactored constructors for `Assignment`, `FunctionCall`, and `FunctionDef` to improve readability and consistency. [[1]](diffhunk://#diff-e81656bf73c8b822150d0cb3035d038246a07567ed9d3e7cc4bb8b89b659099dL18-L22) [[2]](diffhunk://#diff-d90edb7dbe46419652e516d59995636e7a68e9b49765848c8b00b4b7d8d14439L13-R41) [[3]](diffhunk://#diff-1a78aa6d11659f866d79615e7ae738060a004be5c58416ad02f58f4872ca9c30L38-R40)
* Improved `Identifier` code generation to handle variable loading from the symbol table and emit LLVM IR.
* Updated `ExpressionList` and `Block` to iterate over expressions and generate LLVM IR for each. [[1]](diffhunk://#diff-d3ea80b21084986eddfad144dab1fa3239c2548aa84ee0b140d64a69f9977905L20-R24) [[2]](diffhunk://#diff-d3ea80b21084986eddfad144dab1fa3239c2548aa84ee0b140d64a69f9977905L33-R48)

### New Methods for LLVM IR Generation:
* Introduced `generate_string_const_name` and `register_variable` in `CodegenContext` for handling string constants and variable registration.
* Added `emit_global` in `CodegenContext` to support emitting global-level LLVM IR.

### Minor Adjustments:
* Cleaned up imports and improved formatting across multiple files for better organization and readability. [[1]](diffhunk://#diff-d3ea80b21084986eddfad144dab1fa3239c2548aa84ee0b140d64a69f9977905L1-R3) [[2]](diffhunk://#diff-109d953da919e7d3bbd538b66dca8e377ac7b200a8f73c0c6b41a8fb12170066L1-R3) [[3]](diffhunk://#diff-3370e7776ef4465cd0a618cfd81270b6f4521420023bd249e834ceaf1a00ec37L1-L18) [[4]](diffhunk://#diff-d90edb7dbe46419652e516d59995636e7a68e9b49765848c8b00b4b7d8d14439L1-R3) F95ea7bcL1, [[5]](diffhunk://#diff-9d31e484b2381d2a73d88b4c7b2ad77385d0e992e08dea4031bf7dee0de2c514L1-R4) [[6]](diffhunk://#diff-44812caa370c5a040611324060ca70a957821d1f808dbd78487e8444cd0fa42aL1-R3)

These changes collectively enhance the compiler's ability to generate LLVM IR, improve code maintainability, and prepare the groundwork for future features.