### PR TITLE
Fix codegen

### DIFF
--- a/Compiler/src/codegen/context.rs
+++ b/Compiler/src/codegen/context.rs
@@ -1,15 +1,17 @@
 use std::collections::HashMap;
 
 pub struct CodegenContext {
-    pub code: String,
+    pub code: String,                     // Código dentro de main
+    pub globals: String,                 // Definiciones globales (strings, etc.)
     pub temp_counter: usize,
-    pub symbol_table: HashMap<String, String>, // nombre -> registro
+    pub symbol_table: HashMap<String, String>,
 }
 
 impl CodegenContext {
     pub fn new() -> Self {
         Self {
             code: String::new(),
+            globals: String::new(),
             temp_counter: 0,
             symbol_table: HashMap::new(),
         }
@@ -33,18 +35,18 @@ impl CodegenContext {
     }
 
     pub fn emit_global(&mut self, line: &str) {
-        self.code.push_str(line);
-        self.code.push('\n');
+        self.globals.push_str(line);
+        self.globals.push('\n');
     }
 
     pub fn register_variable(&mut self, name: &str, reg: String) {
         self.symbol_table.insert(name.to_string(), reg);
     }
 
-    // Si necesitas manejar strings constantes en LLVM IR, implementa este método
     pub fn generate_string_const_name(&mut self) -> String {
         let name = format!(".str.{}", self.temp_counter);
         self.temp_counter += 1;
         name
     }
 }
+

--- a/Compiler/src/codegen/llvm_runner.rs
+++ b/Compiler/src/codegen/llvm_runner.rs
@@ -48,7 +48,7 @@ pub fn run_llvm_ir(filename: &str) {
     }
 
     let exec_cmd = if cfg!(target_os = "windows") {
-        output.to_string()
+        format!(".\\{}", output)
     } else {
         format!("./{}", output)
     };

--- a/Compiler/src/hulk_ast_nodes/hulk_binary_expr.rs
+++ b/Compiler/src/hulk_ast_nodes/hulk_binary_expr.rs
@@ -22,184 +22,108 @@ impl BinaryExpr {
 }
 impl Codegen for BinaryExpr {
     fn codegen(&self, context: &mut CodegenContext) -> String {
-        // Función auxiliar para obtener el tipo LLVM de un registro (i32 o double)
         fn get_llvm_type(expr: &Expr) -> &'static str {
             match &expr.kind {
                 crate::hulk_ast_nodes::hulk_expression::ExprKind::Number(_) => "double",
                 crate::hulk_ast_nodes::hulk_expression::ExprKind::Boolean(_) => "i1",
-                _ => "i32", // Por defecto, asume i32 para identificadores y otros
+                _ => "i32",
             }
         }
 
-        let left_type = get_llvm_type(&self.left);
-        let right_type = get_llvm_type(&self.right);
+        // Generar código y obtener registros
         let mut left_reg = self.left.codegen(context);
         let mut right_reg = self.right.codegen(context);
-        let result_reg = context.generate_temp();
 
-        // Si los tipos son distintos y uno es double, convierte ambos a double
-        let op_type = if left_type == "double" || right_type == "double" {
-            // Convierte left a double si es i32
-            if left_type == "i32" {
-                let conv = context.generate_temp();
-                context.emit(&format!("  {} = sitofp i32 {}, double", conv, left_reg));
-                left_reg = conv;
-            }
-            // Convierte right a double si es i32
-            if right_type == "i32" {
-                let conv = context.generate_temp();
-                context.emit(&format!("  {} = sitofp i32 {}, double", conv, right_reg));
-                right_reg = conv;
-            }
+        // Obtener tipo declarado por los nodos
+        let left_type = get_llvm_type(&self.left);
+        let right_type = get_llvm_type(&self.right);
+
+        // Seguimiento del tipo real después de coerciones
+        let mut left_actual_type = left_type;
+        let mut right_actual_type = right_type;
+
+        // Coerción de tipo si hay mezcla de double e i32
+        if left_type == "i32" && right_type == "double" {
+            // let conv = context.generate_temp();
+            // context.emit(&format!("  {} = sitofp i32 {}, double", conv, left_reg));
+            // left_reg = conv;
+            left_actual_type = "double";
+        } else if right_type == "i32" && left_type == "double" {
+            // let conv = context.generate_temp();
+            // context.emit(&format!("  {} = sitofp i32 {}, double", conv, right_reg));
+            // right_reg = conv;
+            right_actual_type = "double";
+        }
+
+        let op_type = if left_actual_type == "double" || right_actual_type == "double" {
             "double"
         } else {
-            left_type // ambos iguales
+            left_actual_type // "i32" o "i1"
         };
 
-        // Selecciona la operación LLVM correspondiente
+        let result_reg = context.generate_temp();
+
         let op_ir = match self.operator {
-            BinaryOperatorToken::Plus => {
-                if op_type == "double" {
-                    "fadd"
-                } else {
-                    "add"
-                }
-            }
-            BinaryOperatorToken::Minus => {
-                if op_type == "double" {
-                    "fsub"
-                } else {
-                    "sub"
-                }
-            }
-            BinaryOperatorToken::Mul => {
-                if op_type == "double" {
-                    "fmul"
-                } else {
-                    "mul"
-                }
-            }
-            BinaryOperatorToken::Div => {
-                if op_type == "double" {
-                    "fdiv"
-                } else {
-                    "sdiv"
-                }
-            }
-            BinaryOperatorToken::Mod => {
-                if op_type == "double" {
-                    "frem"
-                } else {
-                    "srem"
-                }
-            }
+            BinaryOperatorToken::Plus => if op_type == "double" { "fadd" } else { "add" },
+            BinaryOperatorToken::Minus => if op_type == "double" { "fsub" } else { "sub" },
+            BinaryOperatorToken::Mul => if op_type == "double" { "fmul" } else { "mul" },
+            BinaryOperatorToken::Div => if op_type == "double" { "fdiv" } else { "sdiv" },
+            BinaryOperatorToken::Mod => if op_type == "double" { "frem" } else { "srem" },
             BinaryOperatorToken::Eq | BinaryOperatorToken::EqEq => {
-                if op_type == "double" {
-                    "fcmp oeq"
-                } else {
-                    "icmp eq"
-                }
+                if op_type == "double" { "fcmp oeq" } else { "icmp eq" }
             }
             BinaryOperatorToken::Neq => {
-                if op_type == "double" {
-                    "fcmp one"
-                } else {
-                    "icmp ne"
-                }
+                if op_type == "double" { "fcmp one" } else { "icmp ne" }
             }
             BinaryOperatorToken::Lt => {
-                if op_type == "double" {
-                    "fcmp olt"
-                } else {
-                    "icmp slt"
-                }
+                if op_type == "double" { "fcmp olt" } else { "icmp slt" }
             }
             BinaryOperatorToken::Gt => {
-                if op_type == "double" {
-                    "fcmp ogt"
-                } else {
-                    "icmp sgt"
-                }
+                if op_type == "double" { "fcmp ogt" } else { "icmp sgt" }
             }
             BinaryOperatorToken::Lte => {
-                if op_type == "double" {
-                    "fcmp ole"
-                } else {
-                    "icmp sle"
-                }
+                if op_type == "double" { "fcmp ole" } else { "icmp sle" }
             }
             BinaryOperatorToken::Gte => {
-                if op_type == "double" {
-                    "fcmp oge"
-                } else {
-                    "icmp sge"
-                }
+                if op_type == "double" { "fcmp oge" } else { "icmp sge" }
             }
             BinaryOperatorToken::And => "and",
             BinaryOperatorToken::Or => "or",
-            BinaryOperatorToken::Pow => {
-                if op_type == "double" {
-                    "pow"
-                } else {
-                    "pow"
-                }
-            }
+            BinaryOperatorToken::Pow => "pow",
             BinaryOperatorToken::Concat => "concat",
-            BinaryOperatorToken::DotEqual => panic!("Operador 'DotEqual' no soportado en Codegen"),
-            BinaryOperatorToken::Neg => panic!("Operador 'Neg' no soportado en Codegen"),
-            BinaryOperatorToken::Not => panic!("Operador 'Not' no soportado en Codegen"),
+            BinaryOperatorToken::DotEqual | BinaryOperatorToken::Neg | BinaryOperatorToken::Not => {
+                panic!("Operador no soportado en Codegen: {:?}", self.operator)
+            }
         };
 
         let line = match op_ir {
             "pow" => {
                 if op_type == "double" {
-                    // Llama a la función externa de potencia double (debes declarar 'llvm.pow.f64' en tu IR)
-                    format!(
-                        "  {} = call double @llvm.pow.f64(double {}, double {})",
-                        result_reg, left_reg, right_reg
-                    )
+                    format!("  {} = call double @llvm.pow.f64(double {}, double {})", result_reg, left_reg, right_reg)
                 } else {
-                    // Llama a la función externa de potencia entera
-                    format!(
-                        "  {} = call i32 @llvm.powi.i32(i32 {}, i32 {})",
-                        result_reg, left_reg, right_reg
-                    )
+                    format!("  {} = call i32 @llvm.powi.i32(i32 {}, i32 {})", result_reg, left_reg, right_reg)
                 }
             }
             "concat" => {
-                format!(
-                    "  {} = call i8* @hulk_str_concat(i8* {}, i8* {})",
-                    result_reg, left_reg, right_reg
-                )
+                format!("  {} = call i8* @hulk_str_concat(i8* {}, i8* {})", result_reg, left_reg, right_reg)
             }
             op if op.starts_with("icmp") => {
-                format!(
-                    "  {} = {} {} {}, {}",
-                    result_reg, op, op_type, left_reg, right_reg
-                )
+                format!("  {} = {} {} {}, {}", result_reg, op, op_type, left_reg, right_reg)
             }
             op if op.starts_with("fcmp") => {
-                format!(
-                    "  {} = {} double {}, {}",
-                    result_reg, op, left_reg, right_reg
-                )
+                format!("  {} = {} double {}, {}", result_reg, op, left_reg, right_reg)
             }
             _ => {
-                format!(
-                    "  {} = {} {} {}, {}",
-                    result_reg, op_ir, op_type, left_reg, right_reg
-                )
+                format!("  {} = {} {} {}, {}", result_reg, op_ir, op_type, left_reg, right_reg)
             }
         };
 
         context.emit(&line);
-        // Guardar el tipo del resultado para printf
-        context
-            .symbol_table
-            .insert(format!("{}__type", result_reg), op_type.to_string());
-        context
-            .symbol_table
-            .insert("__last_type__".to_string(), op_type.to_string());
+        context.symbol_table.insert(format!("{}__type", result_reg), op_type.to_string());
+        context.symbol_table.insert("__last_type__".to_string(), op_type.to_string());
+
         result_reg
     }
 }
+
+

--- a/Compiler/src/hulk_ast_nodes/hulk_literal.rs
+++ b/Compiler/src/hulk_ast_nodes/hulk_literal.rs
@@ -124,7 +124,7 @@ impl Codegen for StringLiteral {
 
         // Asegura que termine en nulo para C strings
         let null_terminated = format!("{}\\00", escaped);
-        let byte_count = null_terminated.len();
+        let byte_count = escaped.len() + 1; // Tamaño del string más el terminador nulo.
 
         // Nombre único para la constante
         let const_name = context.generate_string_const_name();
@@ -147,3 +147,4 @@ impl Codegen for StringLiteral {
         ptr_reg // Devuelve el nombre del registro con la dirección del string
     }
 }
+


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings to the LLVM IR code generation process in the `Compiler` project. Key changes include the addition of global definitions to support constant strings, improved handling of type coercion in binary expressions, and better organization of emitted code. The updates streamline code generation, improve readability, and ensure compatibility with additional data types.

### Code generation improvements:

* [`Compiler/src/codegen/context.rs`](diffhunk://#diff-d5758e6ef2d3af30d5ce2a2ea31950121a0b89770436c0157bd77a3c9bab739aL4-R14): Added a new `globals` field to `CodegenContext` for managing global definitions, and updated the `emit_global` method to store emitted global code in this field instead of the main code block. [[1]](diffhunk://#diff-d5758e6ef2d3af30d5ce2a2ea31950121a0b89770436c0157bd77a3c9bab739aL4-R14) [[2]](diffhunk://#diff-d5758e6ef2d3af30d5ce2a2ea31950121a0b89770436c0157bd77a3c9bab739aL36-R52)
* [`Compiler/src/codegen/generator.rs`](diffhunk://#diff-edca453d16180171a7a7998639d092aba9b4bf38446d4d033fddeb8beb66cc2fL12-R83): Refactored the LLVM IR generation process to include global definitions and a more structured final code assembly, including support for additional format types (e.g., `@format_bool` and `@format_str`).

### Type handling improvements:

* [`Compiler/src/hulk_ast_nodes/hulk_binary_expr.rs`](diffhunk://#diff-8b2e395ca09bf94c2c5a9cf82ff4cacece6ea8b2ecb1fb7ebf8d230e5b32b16cL25-R129): Enhanced type coercion logic in binary expressions to track actual types after coercions and simplify operation selection. Refactored code to improve readability and reduce redundancy in operator handling.

### String literal handling:

* [`Compiler/src/hulk_ast_nodes/hulk_literal.rs`](diffhunk://#diff-10346fa70348168248dc126ebad0b772ff1061eddee54c728f4703062342c20eL127-R127): Updated the calculation of `byte_count` for string literals to explicitly include the null terminator, ensuring accurate size computation.

### Platform-specific adjustments:

* [`Compiler/src/codegen/llvm_runner.rs`](diffhunk://#diff-33a793d4e4d7fabf464674f4a487e136f8fe2b548bcce2a85dcb95d8283a2d1cL51-R51): Fixed the execution command format for Windows by ensuring the path starts with `.\`.