### PR TITLE
Fix codegen

### DIFF
--- a/Compiler/src/codegen/generator.rs
+++ b/Compiler/src/codegen/generator.rs
@@ -45,9 +45,54 @@ impl CodeGenerator {
           ret i8* %buf
         }
 
+        ; Compara si dos strings son iguales (devuelve i1)
+        define i1 @hulk_str_eq(i8* %s1, i8* %s2) {
+        entry:
+          %cmp = call i32 @strcmp(i8* %s1, i8* %s2)
+          %is_eq = icmp eq i32 %cmp, 0
+          ret i1 %is_eq
+        }
+
+        ; Compara si s1 > s2 (por longitud)
+        define i1 @hulk_str_gt(i8* %s1, i8* %s2) {
+        entry:
+          %len1 = call i64 @strlen(i8* %s1)
+          %len2 = call i64 @strlen(i8* %s2)
+          %gt = icmp ugt i64 %len1, %len2
+          ret i1 %gt
+        }
+
+        ; Compara si s1 < s2 (por longitud)
+        define i1 @hulk_str_lt(i8* %s1, i8* %s2) {
+        entry:
+          %len1 = call i64 @strlen(i8* %s1)
+          %len2 = call i64 @strlen(i8* %s2)
+          %lt = icmp ult i64 %len1, %len2
+          ret i1 %lt
+        }
+
+        ; Compara si s1 >= s2 (por longitud)
+        define i1 @hulk_str_ge(i8* %s1, i8* %s2) {
+        entry:
+          %len1 = call i64 @strlen(i8* %s1)
+          %len2 = call i64 @strlen(i8* %s2)
+          %ge = icmp uge i64 %len1, %len2
+          ret i1 %ge
+        }
+
+        ; Compara si s1 <= s2 (por longitud)
+        define i1 @hulk_str_le(i8* %s1, i8* %s2) {
+        entry:
+          %len1 = call i64 @strlen(i8* %s1)
+          %len2 = call i64 @strlen(i8* %s2)
+          %le = icmp ule i64 %len1, %len2
+          ret i1 %le
+        }
+
         declare i64 @strlen(i8*)
         declare i8* @malloc(i64)
         declare void @llvm.memcpy.p0i8.p0i8.i64(i8*, i8*, i64, i1)
+        declare i32 @strcmp(i8*, i8*)
         "#
         );
         final_code.push_str("@format_int = private constant [4 x i8] c\"%d\\0A\\00\"\n");

--- a/Compiler/src/hulk_ast_nodes/hulk_destructive_assign.rs
+++ b/Compiler/src/hulk_ast_nodes/hulk_destructive_assign.rs
@@ -44,13 +44,41 @@ impl DestructiveAssignment {
     }
 }
 
+// impl Codegen for DestructiveAssignment {
+//     /// Genera el código LLVM IR para la asignación destructiva.
+//     ///
+//     /// Busca el puntero de la variable en el contexto y almacena el valor generado por la expresión.
+//     /// Si la variable no existe en el contexto, lanza un panic.
+//     fn codegen(&self, context: &mut CodegenContext) -> String {
+
+//         let var_name = match *self.identifier {
+//             Expr {
+//                 kind: ExprKind::Identifier(ref name),
+//                 ..
+//             } => name,
+//             _ => panic!("Expected identifier on left side of destructive assignment"),
+//         };
+//         let ptr = context.symbol_table.get(&var_name.to_string()).cloned();
+//         if let Some(ptr) = ptr {
+//             let value_reg = self.expression.codegen(context);
+//             context.emit(&format!("  store i32 {}, i32* {}", value_reg, ptr));
+//             value_reg
+//         } else {
+//             panic!(
+//                 "Variable '{}' no definida en el contexto para asignación destructiva",
+//                 var_name
+//             );
+//         }
+//     }
+// }
+
 impl Codegen for DestructiveAssignment {
     /// Genera el código LLVM IR para la asignación destructiva.
     ///
     /// Busca el puntero de la variable en el contexto y almacena el valor generado por la expresión.
     /// Si la variable no existe en el contexto, lanza un panic.
     fn codegen(&self, context: &mut CodegenContext) -> String {
-
+        // Obtener el nombre de la variable
         let var_name = match *self.identifier {
             Expr {
                 kind: ExprKind::Identifier(ref name),
@@ -58,16 +86,23 @@ impl Codegen for DestructiveAssignment {
             } => name,
             _ => panic!("Expected identifier on left side of destructive assignment"),
         };
-        let ptr = context.symbol_table.get(&var_name.to_string()).cloned();
-        if let Some(ptr) = ptr {
-            let value_reg = self.expression.codegen(context);
-            context.emit(&format!("  store i32 {}, i32* {}", value_reg, ptr));
-            value_reg
-        } else {
-            panic!(
-                "Variable '{}' no definida en el contexto para asignación destructiva",
-                var_name
-            );
-        }
+
+        // Obtener el puntero de la variable del symbol_table
+        let ptr = context.symbol_table.get(&var_name.id).cloned().unwrap_or_else(|| {
+            panic!("Variable '{}' no definida en el contexto para asignación destructiva", var_name)
+        });
+
+        // Generar el valor de la expresión
+        let value_reg = self.expression.codegen(context);
+
+        // Obtener el tipo inferido
+        let hulk_type = self._type.clone().expect("DestructiveAssignment debe tener tipo inferido");
+        let llvm_type = CodegenContext::to_llvm_type(hulk_type.type_name);
+
+        // Asegurarse que el puntero también tiene el tipo correcto en la tabla de símbolos
+        // (esto es importante si el puntero es a i8*, o i1, o double)
+        context.emit(&format!("  store {} {}, {}* {}", llvm_type, value_reg, llvm_type, ptr));
+        
+        value_reg
     }
 }

--- a/Compiler/src/main.rs
+++ b/Compiler/src/main.rs
@@ -217,7 +217,7 @@ else {
         //     break;
         // }
 
-        let mut parsed_expr = parser.parse(&boolean_test).unwrap();
+        let mut parsed_expr = parser.parse(&input_hulk).unwrap();
         let mut print_visitor = PreetyPrintVisitor;
         let mut semantic_visitor = SemanticVisitor::new();
         let res = semantic_visitor.check(&mut parsed_expr);


### PR DESCRIPTION
This pull request introduces enhancements to the code generation logic in the compiler, focusing on type coercion, string comparison, and loop handling. Additionally, it improves the handling of variable types and iterators in the symbol table, ensuring better type safety and compatibility. Below is a summary of the most important changes grouped by theme:

### String Comparison Functions
* Added new LLVM IR functions to compare strings, including equality (`@hulk_str_eq`), greater than (`@hulk_str_gt`), less than (`@hulk_str_lt`), greater than or equal (`@hulk_str_ge`), and less than or equal (`@hulk_str_le`). These functions use `strcmp` and `strlen` for comparison. (`Compiler/src/codegen/generator.rs`, [Compiler/src/codegen/generator.rsR48-R95](diffhunk://#diff-edca453d16180171a7a7998639d092aba9b4bf38446d4d033fddeb8beb66cc2fR48-R95))

### Type Coercion Logic
* Reintroduced and refined type coercion logic in `BinaryExpr` to handle type mismatches between operands (e.g., converting `i1` to `double` or `i32`). This ensures compatibility during binary operations. (`Compiler/src/hulk_ast_nodes/hulk_binary_expr.rs`, [Compiler/src/hulk_ast_nodes/hulk_binary_expr.rsL194-R239](diffhunk://#diff-8b2e395ca09bf94c2c5a9cf82ff4cacece6ea8b2ecb1fb7ebf8d230e5b32b16cL194-R239))
* Updated handling of binary operators (e.g., `Eq`, `Neq`, `Lt`, `Gt`, `Lte`, `Gte`) to use the newly added string comparison functions for `i8*` types. (`Compiler/src/hulk_ast_nodes/hulk_binary_expr.rs`, [Compiler/src/hulk_ast_nodes/hulk_binary_expr.rsL256-R301](diffhunk://#diff-8b2e395ca09bf94c2c5a9cf82ff4cacece6ea8b2ecb1fb7ebf8d230e5b32b16cL256-R301))

### Improved Loop Code Generation
* Enhanced `ForExpr` code generation to support inferred types for loop variables, ensuring the correct LLVM type is used during allocation and operations. (`Compiler/src/hulk_ast_nodes/hulk_for_expr.rs`, [Compiler/src/hulk_ast_nodes/hulk_for_expr.rsR54-R157](diffhunk://#diff-5303c089ccb0446d9a3e1b5c5e7060c47cfbffc02283a7bc2923e5471f0d5019R54-R157))
* Updated loop increment logic to handle non-integer types, using appropriate LLVM operations like `fadd` for floating-point addition. (`Compiler/src/hulk_ast_nodes/hulk_for_expr.rs`, [Compiler/src/hulk_ast_nodes/hulk_for_expr.rsL96-R185](diffhunk://#diff-5303c089ccb0446d9a3e1b5c5e7060c47cfbffc02283a7bc2923e5471f0d5019L96-R185))

### Destructive Assignment Enhancements
* Improved `DestructiveAssignment` code generation by ensuring type correctness for both the pointer and the stored value, using inferred types from the symbol table. (`Compiler/src/hulk_ast_nodes/hulk_destructive_assign.rs`, [Compiler/src/hulk_ast_nodes/hulk_destructive_assign.rsR47-L71](diffhunk://#diff-2315b2505ae64d262867b02e23161fce064133f1578d8d9ef35c200ab90b0780R47-L71))

### Miscellaneous Changes
* Fixed a parsing issue in the main entry point by replacing `boolean_test` with `input_hulk` for parsing expressions. (`Compiler/src/main.rs`, [Compiler/src/main.rsL220-R220](diffhunk://#diff-9d499f7282c7a29d44363a315dc41f4e6f88b09809fe19b8ab53232e3787b0c7L220-R220))