### PR TITLE
fix: update storage logic for pointer types in LetIn and Identifier c…

### DIFF
--- a/Compiler/src/hulk_ast_nodes/hulk_identifier.rs
+++ b/Compiler/src/hulk_ast_nodes/hulk_identifier.rs
@@ -88,7 +88,7 @@ impl Codegen for Identifier {
 
         // Si el tipo es un puntero (como i8* para strings), no hace falta hacer load
         match llvm_type.as_str() {
-            "i8*" => ptr,
+            // "i8*" => ptr,
             _ => {
                 let result_reg = context.generate_temp();
                 let line = format!("  {} = load {}, {}* {}", result_reg, llvm_type, llvm_type, ptr);

--- a/Compiler/src/hulk_ast_nodes/hulk_let_in.rs
+++ b/Compiler/src/hulk_ast_nodes/hulk_let_in.rs
@@ -78,7 +78,12 @@ impl Codegen for LetIn {
             // Genera almacenamiento y guarda el valor
             let alloca_reg = context.generate_temp();
             context.emit(&format!("  {} = alloca {}", alloca_reg, llvm_type));
-            context.emit(&format!("  store {} {}, {}* {}", llvm_type, value_reg, llvm_type, alloca_reg));
+            if llvm_type == "ptr" {
+                // Si el tipo es un puntero, almacenamos el valor como un puntero genérico (i8*)
+                context.emit(&format!("  store ptr {}, ptr {}", value_reg, alloca_reg));
+            } else {
+                context.emit(&format!("  store {} {}, {}* {}", llvm_type, value_reg, llvm_type, alloca_reg));
+            }
 
             // Guarda cualquier binding anterior (shadowing reversible)
             let previous = context.symbol_table.get(&name).cloned();


### PR DESCRIPTION
This pull request makes targeted changes to the LLVM code generation logic in the compiler, specifically addressing how pointers are handled during code generation for identifiers and `let-in` expressions. The updates improve type handling and ensure compatibility with generic pointer types (`i8*`).

### Pointer handling improvements:

* **Identifier code generation (`hulk_identifier.rs`)**: Removed the special case for `i8*` pointers in the `Codegen` implementation for `Identifier`. This simplifies the logic by treating all types uniformly, relying on subsequent code to handle loading as needed.

* **Let-in code generation (`hulk_let_in.rs`)**: Added a conditional check in the `Codegen` implementation for `LetIn` to handle `ptr` types explicitly. If the type is a pointer, the value is stored as a generic pointer (`i8*`) instead of using the specific LLVM type, ensuring consistent handling of pointer types.…odegen