### PR TITLE
Fix codegen

### DIFF
--- a/Compiler/src/hulk_ast_nodes/hulk_function_call.rs
+++ b/Compiler/src/hulk_ast_nodes/hulk_function_call.rs
@@ -38,31 +38,76 @@ impl FunctionCall {
     }
 }
 
+// impl Codegen for FunctionCall {
+//     /// Genera el código LLVM IR para la llamada a función.
+//     ///
+//     /// Genera el código para cada argumento, prepara la lista de argumentos para LLVM IR (asumiendo `i32` para todos),
+//     /// obtiene un nuevo registro temporal para el resultado y emite la instrucción de llamada.
+//     fn codegen(&self, context: &mut CodegenContext) -> String {
+//         // Genera el código para cada argumento y obtiene los registros
+//         let arg_regs: Vec<String> = self
+//             .arguments
+//             .iter()
+//             .map(|arg| arg.codegen(context))
+//             .collect();
+//         // Prepara la lista de argumentos para LLVM IR (asume i32 para todos)
+//         let args_str = arg_regs
+//             .iter()
+//             .map(|reg| format!("i32 {}", reg))
+//             .collect::<Vec<_>>()
+//             .join(", ");
+//         // Obtiene un nuevo registro temporal para el resultado
+//         let result_reg = context.generate_temp();
+//         // Emite la instrucción de llamada
+//         context.emit(&format!(
+//             "  {} = call i32 @{}({})",
+//             result_reg, self.funct_name, args_str
+//         ));
+//         result_reg
+//     }
+// }
+
 impl Codegen for FunctionCall {
     /// Genera el código LLVM IR para la llamada a función.
     ///
     /// Genera el código para cada argumento, prepara la lista de argumentos para LLVM IR (asumiendo `i32` para todos),
     /// obtiene un nuevo registro temporal para el resultado y emite la instrucción de llamada.
     fn codegen(&self, context: &mut CodegenContext) -> String {
-        // Genera el código para cada argumento y obtiene los registros
-        let arg_regs: Vec<String> = self
-            .arguments
-            .iter()
-            .map(|arg| arg.codegen(context))
-            .collect();
-        // Prepara la lista de argumentos para LLVM IR (asume i32 para todos)
-        let args_str = arg_regs
-            .iter()
-            .map(|reg| format!("i32 {}", reg))
-            .collect::<Vec<_>>()
-            .join(", ");
-        // Obtiene un nuevo registro temporal para el resultado
+        // 1. Genera el código de los argumentos y guarda los registros y tipos
+        let mut llvm_args = Vec::new();
+
+        for arg in &self.arguments {
+            let reg = arg.codegen(context);
+            // let ty_str = arg.kind
+            let llvm_type = context
+                .symbol_table
+                .get("__last_type__")
+                .cloned()
+                .expect("Tipo no encontrado");
+
+            // let llvm_ty = CodegenContext::to_llvm_type(ty_str);
+            llvm_args.push(format!("{} {}", llvm_type, reg));
+        }
+
+        let args_str = llvm_args.join(", ");
+
+        // 2. Determina el tipo de retorno de la función llamada
+        let return_type_str = context
+            .function_table
+            .get(&self.funct_name)
+            .expect("Tipo de retorno de la función no encontrado");
+
+
+        let llvm_ret_type = CodegenContext::to_llvm_type(return_type_str.to_string());
+
+        // 3. Emitimos la llamada
         let result_reg = context.generate_temp();
-        // Emite la instrucción de llamada
         context.emit(&format!(
-            "  {} = call i32 @{}({})",
-            result_reg, self.funct_name, args_str
+            "  {} = call {} @{}({})",
+            result_reg, llvm_ret_type, self.funct_name, args_str
         ));
+
         result_reg
     }
 }
+

--- a/Compiler/src/hulk_ast_nodes/hulk_global_function.rs
+++ b/Compiler/src/hulk_ast_nodes/hulk_global_function.rs
@@ -1,4 +1,4 @@
-use crate::{hulk_ast_nodes::{hulk_function_def::{FunctionBody, FunctionHeaderStruct, FunctionParams}, Expr, FunctionDef}, hulk_tokens::KeywordToken};
+use crate::{codegen::{context::CodegenContext, traits::Codegen}, hulk_ast_nodes::{hulk_function_def::{FunctionBody, FunctionHeaderStruct, FunctionParams}, Expr, FunctionDef}, hulk_tokens::KeywordToken};
 
 #[derive(Debug, Clone)]
 pub struct GlobalFunctionDef {
@@ -24,5 +24,11 @@ impl GlobalFunctionDef {
             function_token,
             function_def: FunctionDef::from_header(header, body)
         }
+    }
+}
+
+impl Codegen for GlobalFunctionDef {
+    fn codegen(&self, context: &mut CodegenContext) -> String {
+        self.function_def.codegen(context)
     }
 }

--- a/Compiler/src/hulk_ast_nodes/hulk_let_in.rs
+++ b/Compiler/src/hulk_ast_nodes/hulk_let_in.rs
@@ -60,7 +60,7 @@ impl LetIn {
 }
 
 impl Codegen for LetIn {
-    /// Genera el código LLVM IR para la expresión let-in.
+    /// Genera el código LLVM IR para la expresión `let-in`.
     ///
     /// Reserva espacio para cada variable local, almacena su valor y gestiona el shadowing de variables.
     /// Al finalizar el cuerpo, restaura los bindings anteriores para mantener el alcance correcto.
@@ -81,18 +81,11 @@ impl Codegen for LetIn {
                 .cloned()
                 .expect("Tipo no encontrado para asignación let");
 
-            let llvm_type = if llvm_type == "ptr" {
-                "i8*"
-            } else {
-                &llvm_type
-            };
+            let llvm_type = if llvm_type == "ptr" { "i8*" } else { &llvm_type };
 
             let alloca_reg = context.generate_temp();
             context.emit(&format!("  {} = alloca {}", alloca_reg, llvm_type));
-            context.emit(&format!(
-                "  store {} {}, {}* {}",
-                llvm_type, value_reg, llvm_type, alloca_reg
-            ));
+            context.emit(&format!("  store {} {}, {}* {}", llvm_type, value_reg, llvm_type, alloca_reg));
 
             // Guarda cualquier binding anterior (shadowing reversible)
             let previous = context.symbol_table.get(&name).cloned();
@@ -102,7 +95,7 @@ impl Codegen for LetIn {
             context.register_variable(&name, alloca_reg);
         }
 
-        // Genera el cuerpo de la expresión in
+        // Genera el cuerpo de la expresión `in`
         let body_reg = self.body.codegen(context);
 
         // Restaura bindings anteriores

--- a/Compiler/src/hulk_ast_nodes/hulk_program.rs
+++ b/Compiler/src/hulk_ast_nodes/hulk_program.rs
@@ -85,45 +85,6 @@ impl Accept for Definition {
 }
 
 
-
-
-/// Enum que representa las instrucciones de alto nivel de un programa Hulk.
-/// 
-/// - `HulkTypeNode`: definición de tipo/clase.
-/// - `FunctionDef`: definición de función.
-/// - `Expression`: expresión evaluable.
-
-
-// #[derive(Debug, Clone)]
-// pub enum Instruction {
-//     HulkTypeNode(HulkTypeNode),
-//     FunctionDef(FunctionDef),
-//     // Protocol(ProtocolDecl), // Futuro: soporte para protocolos
-//     Expression(Box<Expr>)
-// }
-
-// impl Instruction {
-//     /// Evalúa la instrucción si es una expresión, retornando su valor.
-//     /// Para otros tipos de instrucción, retorna un error.
-//     pub fn eval(&self) -> Result<f64, String> {
-//         match self {
-//             Instruction::Expression(expr) => expr.eval(),
-//             _ => Err("Solo se pueden evaluar expresiones.".to_string()),
-//         }
-//     }
-// }
-
-// impl Accept for Instruction {
-//     /// Permite que la instrucción acepte un visitor.
-//     fn accept<V: Visitor<T>, T>(&mut self, visitor: &mut V) -> T {
-//         match self {
-//             Instruction::Expression(expr) => expr.accept(visitor),
-//             Instruction::FunctionDef(func_def) => visitor.visit_function_def(func_def),
-//             Instruction::HulkTypeNode(type_node) => visitor.visit_type_def(type_node),
-//         }
-//     }
-// }
-
 impl Codegen for ProgramNode {
     /// Genera el código LLVM IR para todo el programa.
     ///
@@ -137,18 +98,33 @@ impl Codegen for ProgramNode {
     }
 }
 
-// impl Codegen for Instruction {
-//     /// Genera el código LLVM IR para una instrucción.
+// impl Codegen for ProgramNode {
+//      /// Genera el código LLVM IR para todo el programa.
 //     ///
-//     /// Soporta generación para funciones y expresiones. Para definiciones de tipo, no genera código por defecto.
+//     /// Recorre todas las instrucciones y genera el código correspondiente.
 //     fn codegen(&self, context: &mut CodegenContext) -> String {
-//         match self {
-//             Instruction::FunctionDef(func_def) => func_def.codegen(context),
-//             Instruction::Expression(expr) => expr.codegen(context),
-//             Instruction::HulkTypeNode(_type_node) => {
-//                 // Puedes implementar codegen para HulkTypeNode aquí si es necesario
-//                 String::new()
+//         let mut last_reg = String::new();
+
+//         // Primero genera el código de todas las definiciones (funciones y tipos)
+//         for def in &self.definitions {
+//             match def {
+//                 Definition::FunctionDef(func_def) => {
+//                     func_def.codegen(context); // Esto define una función global
+//                 }
+//                 Definition::TypeDef(type_def) => {
+//                     type_def.codegen(context); // Define un tipo personalizado
+//                 }
 //             }
 //         }
+
+//         // Luego genera el código de las instrucciones ejecutables (main, prints, exprs, etc)
+//         for instr in &self.instructions {
+//             last_reg = instr.codegen(context);
+//         }
+
+//         last_reg
 //     }
 // }
+
+
+

--- a/Compiler/src/hulk_ast_nodes/hulk_program.rs
+++ b/Compiler/src/hulk_ast_nodes/hulk_program.rs
@@ -85,46 +85,46 @@ impl Accept for Definition {
 }
 
 
-impl Codegen for ProgramNode {
-    /// Genera el código LLVM IR para todo el programa.
-    ///
-    /// Recorre todas las instrucciones y genera el código correspondiente.
-    fn codegen(&self, context: &mut CodegenContext) -> String {
-        let mut last_reg = String::new();
-        for instr in &self.instructions {
-            last_reg = instr.codegen(context);
-        }
-        last_reg
-    }
-}
-
 // impl Codegen for ProgramNode {
-//      /// Genera el código LLVM IR para todo el programa.
+//     /// Genera el código LLVM IR para todo el programa.
 //     ///
 //     /// Recorre todas las instrucciones y genera el código correspondiente.
 //     fn codegen(&self, context: &mut CodegenContext) -> String {
 //         let mut last_reg = String::new();
-
-//         // Primero genera el código de todas las definiciones (funciones y tipos)
-//         for def in &self.definitions {
-//             match def {
-//                 Definition::FunctionDef(func_def) => {
-//                     func_def.codegen(context); // Esto define una función global
-//                 }
-//                 Definition::TypeDef(type_def) => {
-//                     type_def.codegen(context); // Define un tipo personalizado
-//                 }
-//             }
-//         }
-
-//         // Luego genera el código de las instrucciones ejecutables (main, prints, exprs, etc)
 //         for instr in &self.instructions {
 //             last_reg = instr.codegen(context);
 //         }
-
 //         last_reg
 //     }
 // }
+
+impl Codegen for ProgramNode {
+     /// Genera el código LLVM IR para todo el programa.
+    ///
+    /// Recorre todas las instrucciones y genera el código correspondiente.
+    fn codegen(&self, context: &mut CodegenContext) -> String {
+        let mut last_reg = String::new();
+
+        // Primero genera el código de todas las definiciones (funciones y tipos)
+        for def in &self.definitions {
+            match def {
+                Definition::FunctionDef(func_def) => {
+                    func_def.codegen(context); // Esto define una función global
+                }
+                Definition::TypeDef(type_def) => {
+                    type_def.codegen(context); // Define un tipo personalizado
+                }
+            }
+        }
+
+        // Luego genera el código de las instrucciones ejecutables (main, prints, exprs, etc)
+        for instr in &self.instructions {
+            last_reg = instr.codegen(context);
+        }
+
+        last_reg
+    }
+}
 
 
 

--- a/Compiler/src/hulk_ast_nodes/hulk_type_def.rs
+++ b/Compiler/src/hulk_ast_nodes/hulk_type_def.rs
@@ -5,6 +5,8 @@
 //! Incluye métodos para construir tipos, agregar herencia, atributos y métodos, y establecer el tipo inferido o declarado.
 
 use std::collections::HashMap;
+use crate::codegen::context::CodegenContext;
+use crate::codegen::traits::Codegen;
 use crate::hulk_ast_nodes::hulk_expression::Expr;
 use crate::hulk_ast_nodes::hulk_function_def::{FunctionDef, FunctionParams};
 use crate::hulk_ast_nodes::hulk_identifier::Identifier;
@@ -88,3 +90,10 @@ impl HulkTypeNode {
         self._type = Some(_type);
     }
 }
+
+impl Codegen for HulkTypeNode {
+    fn codegen(&self, _context: &mut CodegenContext) -> String {
+        "HulkTypeNode codegen placeholder".to_string()
+    }
+}
+


### PR DESCRIPTION
This pull request introduces several enhancements to the LLVM code generation process for the Hulk language compiler, focusing on improving type handling, function definitions, and overall program structure. Key changes include the addition of type and function tables for better type resolution, updates to function and variable code generation to support custom types, and improvements to the handling of global and local contexts.

### Enhancements to `CodegenContext`:

* Added `type_table` and `function_table` to `CodegenContext` for managing type mappings and function return types. New methods `register_type`, `get_type`, and `merge_into_global` were introduced for better type resolution and context merging. (`Compiler/src/codegen/context.rs`, [[1]](diffhunk://#diff-d5758e6ef2d3af30d5ce2a2ea31950121a0b89770436c0157bd77a3c9bab739aR8-R9) [[2]](diffhunk://#diff-d5758e6ef2d3af30d5ce2a2ea31950121a0b89770436c0157bd77a3c9bab739aR19-R36)

### Improved Function Code Generation:

* Updated `FunctionCall` code generation to dynamically determine argument types and function return types using `type_table` and `function_table`. This ensures accurate LLVM IR generation for function calls. (`Compiler/src/hulk_ast_nodes/hulk_function_call.rs`, [Compiler/src/hulk_ast_nodes/hulk_function_call.rsR41-R113](diffhunk://#diff-7b4795441d552c460fca4e201ab9448010a932257290703b097b02ded5fe9795R41-R113))
* Enhanced `FunctionDef` to use isolated subcontexts for function code generation, allowing recursive calls and better type handling. Added logic to merge generated code into the global context and register functions in `function_table`. (`Compiler/src/hulk_ast_nodes/hulk_function_def.rs`, [Compiler/src/hulk_ast_nodes/hulk_function_def.rsR187-R300](diffhunk://#diff-bc913a89921aaa23c3808bb55aae164474606d3c52a517bd8fd3ebd68ac54164R187-R300))

### Enhanced Variable and Expression Handling:

* Improved `LetIn` code generation to handle type-specific storage and ensure proper shadowing of variables. Added logic to determine LLVM types dynamically for local variable assignments. (`Compiler/src/hulk_ast_nodes/hulk_let_in.rs`, [[1]](diffhunk://#diff-bd6fd275fe4efd6cd1035c4313d33a6540ad2419b69363563ce725523b229a39L71-R95) [[2]](diffhunk://#diff-bd6fd275fe4efd6cd1035c4313d33a6540ad2419b69363563ce725523b229a39L96-R105)

### Global and Program Code Generation:

* Added `Codegen` implementation for `GlobalFunctionDef` to delegate code generation to the underlying function definition. (`Compiler/src/hulk_ast_nodes/hulk_global_function.rs`, [Compiler/src/hulk_ast_nodes/hulk_global_function.rsR29-R34](diffhunk://#diff-ae8a622bf4a0b677eba7534c54a37ddd77655b601f92e7e8874aa82b54178559R29-R34))
* Enhanced `ProgramNode` code generation to separate global definitions (functions and types) from executable instructions, ensuring proper ordering and context management. (`Compiler/src/hulk_ast_nodes/hulk_program.rs`, [Compiler/src/hulk_ast_nodes/hulk_program.rsR107-R130](diffhunk://#diff-78b19481cd9dd3d658ab0c16d85a28ca14aae013dd0c7efd1785cf7720503c9fR107-R130))

### Type Definitions:

* Introduced a placeholder `Codegen` implementation for `HulkTypeNode` to prepare for future support of custom type definitions. (`Compiler/src/hulk_ast_nodes/hulk_type_def.rs`, [Compiler/src/hulk_ast_nodes/hulk_type_def.rsR93-R99](diffhunk://#diff-9080421c2a0bb5f5b3d4d8a08b551cd9f852dadc12214da699e7f0f32d49c131R93-R99))